### PR TITLE
build: upgrade to Go 1.21.7

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,4 +9,4 @@ jobs:
   release:
     uses: itzg/github-workflows/.github/workflows/go-with-releaser.yml@main
     with:
-      go-version: "1.21.5"
+      go-version: "1.21.7"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,4 +8,4 @@ jobs:
   test:
     uses: itzg/github-workflows/.github/workflows/go-test.yml@main
     with:
-      go-version: "1.21.4"
+      go-version: "1.21.7"


### PR DESCRIPTION
## Packages and Vulnerabilities

   0C     1H     0M     0L  stdlib 1.21.4
pkg:golang/stdlib@1.21.4

27: sha256:c22d96aace68a3f307ecb87bae372d034c68c124f8678c519d70a2159ae28191
/usr/bin/easy-add (evident by)

    x HIGH CVE-2023-45283
      https://scout.docker.com/v/CVE-2023-45283
      Affected range : >=1.21.4
                     : <1.21.5
      Fixed version  : 1.21.5