### PR TITLE
deps: upgrade to Go 1.22.5 to fix vulnerabilities 

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,4 +9,4 @@ jobs:
   release:
     uses: itzg/github-workflows/.github/workflows/go-with-releaser.yml@main
     with:
-      go-version: "1.22.4"
+      go-version: "1.22.5"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,4 +10,4 @@ jobs:
   test:
     uses: itzg/github-workflows/.github/workflows/go-test.yml@main
     with:
-      go-version: "1.22.4"
+      go-version: "1.22.5"


### PR DESCRIPTION
HIGH: https://pkg.go.dev/vuln/GO-2024-2963