### PR TITLE
fix(deps): update go-version to v1.23.6 - fix #37

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,4 +9,4 @@ jobs:
   release:
     uses: itzg/github-workflows/.github/workflows/go-with-releaser.yml@main
     with:
-      go-version: "1.22.7"
+      go-version: "1.23.6"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,4 +10,4 @@ jobs:
   test:
     uses: itzg/github-workflows/.github/workflows/go-test.yml@main
     with:
-      go-version: "1.22.7"
+      go-version: "1.23.6"


### PR DESCRIPTION
HIGH: https://nvd.nist.gov/vuln/detail/CVE-2025-22866