### PR TITLE
Added: RISCV64 support

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,6 +10,7 @@ builds:
     - amd64
     - arm
     - arm64
+    - riscv64
   goarm:
     - "7"
 archives:


### PR DESCRIPTION
I would like to add RISCV64 in project [docker-minecraft-server](https://github.com/itzg/docker-minecraft-server).
So this is the first step!